### PR TITLE
Apply rabbitMQ-params to stepExec services

### DIFF
--- a/shippable.jobs.yml
+++ b/shippable.jobs.yml
@@ -128,6 +128,7 @@ jobs:
   - name: deploy-beta-api
     type: deploy
     steps:
+      - IN: trigger-deploy
       - IN: man-api
       - IN: beta-bitbuc-params
       - IN: beta-braintree-prms
@@ -396,6 +397,12 @@ jobs:
       - IN: beta-docOpts
       - IN: beta-prm
       - IN: beta-clust
+      - IN: rabbitMQ-params
+        applyTo:
+          - man-rSyncSteps
+          - man-manifestSteps
+          - man-deploySteps
+          - man-releaseSteps
 
   - name: man-sync
     type: manifest

--- a/shippable.resources.yml
+++ b/shippable.resources.yml
@@ -147,8 +147,8 @@ resources:
       params:
         SHIPPABLE_FE_URL: "https://beta.shippable.com"
         API_PORT: "443"
-        VORTEX_QUEUE_LIST: "www.sockets|core.marshaller|marshaller.ec2|micro.ini|cluster.init|core.nf|nf.email|nf.hipchat|nf.irc|nf.slack|nf.webhook|core.iscan|iscan.isync|iscan.esync|core.hubspotSync|core.barge|barge.acs|barge.dcl|barge.ddc|barge.ebs|barge.ecs|barge.gke|micro.cu|micro.su|barge.triton|job.request|job.trigger|core.braintree|core.certgen|core.sync|versions.trigger|gitRepo.sync|steps.manifestSteps|steps.runCISteps|steps.releaseSteps||steps.runShSteps|steps.rSyncSteps|steps.deploySteps|core.charon"
-        ROOT_QUEUE_LIST: "isync.autod"
+        VORTEX_QUEUE_LIST: "www.sockets|core.marshaller|marshaller.ec2|micro.ini|cluster.init|core.nf|nf.email|nf.hipchat|nf.irc|nf.slack|nf.webhook|core.iscan|iscan.isync|iscan.esync|core.hubspotSync|core.barge|barge.acs|barge.dcl|barge.ddc|barge.ebs|barge.ecs|barge.gke|micro.cu|micro.su|barge.triton|job.request|job.trigger|core.braintree|core.certgen|core.sync|versions.trigger|gitRepo.sync|steps.runCISteps|steps.runShSteps|core.charon"
+        ROOT_QUEUE_LIST: "isync.autod|steps.rSyncSteps|steps.manifestSteps|steps.deploySteps|steps.releaseSteps"
 
   - name: www-repo
     type: gitRepo

--- a/shippable.triggers.yml
+++ b/shippable.triggers.yml
@@ -7,4 +7,4 @@ triggers:
    - name: trigger-deploy
      type: trigger
      version:
-       counter: 5
+       counter: 6


### PR DESCRIPTION
https://github.com/Shippable/micro/issues/3014

- Moves stepExec services to shippableRoot vhost
- Updates api queue lists accordingly
- Triggers the deploys on api and the stepExec services