### PR TITLE
Move triton to shippableRoot vhost

### DIFF
--- a/shippable.jobs.yml
+++ b/shippable.jobs.yml
@@ -345,6 +345,7 @@ jobs:
           - man-ddc
           - man-dcl
           - man-gke
+          - man-triton
 
 
   - name: man-charon

--- a/shippable.resources.yml
+++ b/shippable.resources.yml
@@ -152,8 +152,8 @@ resources:
       params:
         SHIPPABLE_FE_URL: "https://beta.shippable.com"
         API_PORT: "443"
-        VORTEX_QUEUE_LIST: "www.sockets|core.marshaller|marshaller.ec2|micro.ini|cluster.init|core.nf|nf.email|nf.hipchat|nf.irc|nf.slack|nf.webhook|core.hubspotSync|core.barge|barge.acs|barge.ebs|barge.ecs|micro.cu|micro.su|barge.triton|job.request|job.trigger|core.braintree|core.certgen|core.sync|gitRepo.sync|steps.runCISteps|steps.runShSteps"
-        ROOT_QUEUE_LIST: "core.iscan|iscan.isync|iscan.esync|isync.autod|barge.ddc|barge.dcl|barge.gke|steps.rSyncSteps|steps.manifestSteps|steps.deploySteps|steps.releaseSteps|core.charon|versions.trigger"
+        VORTEX_QUEUE_LIST: "www.sockets|core.marshaller|marshaller.ec2|micro.ini|cluster.init|core.nf|nf.email|nf.hipchat|nf.irc|nf.slack|nf.webhook|core.hubspotSync|core.barge|barge.acs|barge.ebs|barge.ecs|micro.cu|micro.su|job.request|job.trigger|core.braintree|core.certgen|core.sync|gitRepo.sync|steps.runCISteps|steps.runShSteps"
+        ROOT_QUEUE_LIST: "core.iscan|iscan.isync|iscan.esync|isync.autod|barge.ddc|barge.dcl|barge.gke|barge.triton|steps.rSyncSteps|steps.manifestSteps|steps.deploySteps|steps.releaseSteps|core.charon|versions.trigger"
 
   - name: www-repo
     type: gitRepo

--- a/shippable.triggers.yml
+++ b/shippable.triggers.yml
@@ -7,4 +7,4 @@ triggers:
    - name: trigger-deploy
      type: trigger
      version:
-       counter: 14
+       counter: 15


### PR DESCRIPTION
https://github.com/Shippable/micro/issues/3020

- Moves triton to the shippableRoot vhost and triggers a deploy