### PR TITLE
Move ecs to shippableRoot vhost

### DIFF
--- a/shippable.jobs.yml
+++ b/shippable.jobs.yml
@@ -123,13 +123,13 @@ jobs:
   - name: man-api
     type: manifest
     steps:
+      - IN: trigger-deploy
       - IN: api-img
       - IN: api-params
 
   - name: deploy-beta-api
     type: deploy
     steps:
-      - IN: trigger-deploy
       - IN: man-api
       - IN: beta-api-scaler
       - IN: beta-bitbuc-params
@@ -345,6 +345,7 @@ jobs:
           - man-autod
           - man-ddc
           - man-dcl
+          - man-ecs
           - man-gke
           - man-triton
 

--- a/shippable.resources.yml
+++ b/shippable.resources.yml
@@ -152,8 +152,8 @@ resources:
       params:
         SHIPPABLE_FE_URL: "https://beta.shippable.com"
         API_PORT: "443"
-        VORTEX_QUEUE_LIST: "www.sockets|core.marshaller|marshaller.ec2|micro.ini|cluster.init|core.nf|nf.email|nf.hipchat|nf.irc|nf.slack|nf.webhook|core.hubspotSync|core.barge|barge.ebs|barge.ecs|micro.cu|micro.su|job.request|job.trigger|core.braintree|core.certgen|core.sync|gitRepo.sync|steps.runCISteps|steps.runShSteps"
-        ROOT_QUEUE_LIST: "core.iscan|iscan.isync|iscan.esync|isync.autod|barge.acs|barge.ddc|barge.dcl|barge.gke|barge.triton|steps.rSyncSteps|steps.manifestSteps|steps.deploySteps|steps.releaseSteps|core.charon|versions.trigger"
+        VORTEX_QUEUE_LIST: "www.sockets|core.marshaller|marshaller.ec2|micro.ini|cluster.init|core.nf|nf.email|nf.hipchat|nf.irc|nf.slack|nf.webhook|core.hubspotSync|core.barge|barge.ebs|micro.cu|micro.su|job.request|job.trigger|core.braintree|core.certgen|core.sync|gitRepo.sync|steps.runCISteps|steps.runShSteps"
+        ROOT_QUEUE_LIST: "core.iscan|iscan.isync|iscan.esync|isync.autod|barge.acs|barge.ddc|barge.dcl|barge.ecs|barge.gke|barge.triton|steps.rSyncSteps|steps.manifestSteps|steps.deploySteps|steps.releaseSteps|core.charon|versions.trigger"
 
   - name: www-repo
     type: gitRepo

--- a/shippable.triggers.yml
+++ b/shippable.triggers.yml
@@ -7,4 +7,4 @@ triggers:
    - name: trigger-deploy
      type: trigger
      version:
-       counter: 16
+       counter: 17


### PR DESCRIPTION
https://github.com/Shippable/micro/issues/3022

- Moves ECS to shippableRoot vhost