### PR TITLE
Move certgen to shippableRoot vhost

### DIFF
--- a/shippable.jobs.yml
+++ b/shippable.jobs.yml
@@ -266,7 +266,6 @@ jobs:
   - name: deploy-beta-notify
     type: deploy
     steps:
-      - IN: trigger-deploy
       - IN: man-nf
       - IN: man-slack
       - IN: man-email
@@ -336,7 +335,6 @@ jobs:
   - name: deploy-beta-pv1
     type: deploy
     steps:
-      - IN: trigger-deploy
       - IN: man-barge
       - IN: man-acs
       - IN: man-autod
@@ -396,7 +394,6 @@ jobs:
   - name: deploy-beta-pv2
     type: deploy
     steps:
-      - IN: trigger-deploy
       - IN: man-charon
       - IN: man-deploySteps
       - IN: man-manifestSteps
@@ -409,11 +406,11 @@ jobs:
       - IN: beta-clust
       - IN: rabbitMQ-params
         applyTo:
-          - man-rSyncSteps
-          - man-manifestSteps
-          - man-deploySteps
-          - man-releaseSteps
           - man-charon
+          - man-deploySteps
+          - man-manifestSteps
+          - man-releaseSteps
+          - man-rSyncSteps
           - man-versionTrigger
 
   - name: man-sync
@@ -469,6 +466,7 @@ jobs:
   - name: deploy-beta-core
     type: deploy
     steps:
+      - IN: trigger-deploy
       - IN: man-sync
       - IN: man-marshaller
       - IN: man-jobTrigger
@@ -480,6 +478,9 @@ jobs:
       - IN: beta-docOpts
       - IN: beta-prm
       - IN: beta-clust
+      - IN: rabbitMQ-params
+        applyTo:
+          - man-certgen
 
   - name: man-ini
     type: manifest

--- a/shippable.resources.yml
+++ b/shippable.resources.yml
@@ -152,8 +152,8 @@ resources:
       params:
         SHIPPABLE_FE_URL: "https://beta.shippable.com"
         API_PORT: "443"
-        VORTEX_QUEUE_LIST: "www.sockets|core.marshaller|marshaller.ec2|micro.ini|cluster.init|core.hubspotSync|barge.ebs|micro.cu|micro.su|job.request|job.trigger|core.braintree|core.certgen|core.sync|gitRepo.sync|steps.runCISteps|steps.runShSteps"
-        ROOT_QUEUE_LIST: "core.iscan|iscan.isync|iscan.esync|isync.autod|core.barge|barge.acs|barge.ddc|barge.dcl|barge.ecs|barge.gke|barge.triton|steps.rSyncSteps|steps.manifestSteps|steps.deploySteps|steps.releaseSteps|core.charon|versions.trigger|core.nf|nf.email|nf.hipchat|nf.irc|nf.slack|nf.webhook"
+        VORTEX_QUEUE_LIST: "www.sockets|core.marshaller|marshaller.ec2|micro.ini|cluster.init|core.hubspotSync|barge.ebs|micro.cu|micro.su|job.request|job.trigger|core.braintree|core.sync|gitRepo.sync|steps.runCISteps|steps.runShSteps"
+        ROOT_QUEUE_LIST: "core.iscan|iscan.isync|iscan.esync|isync.autod|core.barge|barge.acs|barge.ddc|barge.dcl|barge.ecs|barge.gke|barge.triton|steps.rSyncSteps|steps.manifestSteps|steps.deploySteps|steps.releaseSteps|core.charon|versions.trigger|core.nf|nf.email|nf.hipchat|nf.irc|nf.slack|nf.webhook|core.certgen"
 
   - name: www-repo
     type: gitRepo

--- a/shippable.triggers.yml
+++ b/shippable.triggers.yml
@@ -7,4 +7,4 @@ triggers:
    - name: trigger-deploy
      type: trigger
      version:
-       counter: 24
+       counter: 25


### PR DESCRIPTION
https://github.com/Shippable/micro/issues/3024

- Moves certgen to shippableRoot vhost
- Removes trigger-deploy from deploy-beta-pv1, deploy-beta-pv2, and deploy-beta-notify, since we're done updating those services to the new vhost
- Alphabetizes the services in the pv2 applyTo