### PR TITLE
Move marshaller to shippableRoot vhost

### DIFF
--- a/shippable.jobs.yml
+++ b/shippable.jobs.yml
@@ -467,14 +467,14 @@ jobs:
     type: deploy
     steps:
       - IN: trigger-deploy
-      - IN: man-sync
-      - IN: man-marshaller
-      - IN: man-jobTrigger
-      - IN: man-jobRequest
-      - IN: man-hubspotSync
-      - IN: man-cron
-      - IN: man-certgen
       - IN: man-braintree
+      - IN: man-certgen
+      - IN: man-cron
+      - IN: man-hubspotSync
+      - IN: man-jobRequest
+      - IN: man-jobTrigger
+      - IN: man-marshaller
+      - IN: man-sync
       - IN: beta-docOpts
       - IN: beta-prm
       - IN: beta-clust
@@ -482,6 +482,7 @@ jobs:
         applyTo:
           - man-certgen
           - man-hubspotSync
+          - man-marshaller
           - man-sync
 
   - name: man-ini

--- a/shippable.resources.yml
+++ b/shippable.resources.yml
@@ -152,8 +152,8 @@ resources:
       params:
         SHIPPABLE_FE_URL: "https://beta.shippable.com"
         API_PORT: "443"
-        VORTEX_QUEUE_LIST: "www.sockets|core.marshaller|marshaller.ec2|micro.ini|cluster.init|barge.ebs|micro.cu|micro.su|job.request|job.trigger|core.braintree|gitRepo.sync|steps.runCISteps|steps.runShSteps"
-        ROOT_QUEUE_LIST: "core.iscan|iscan.isync|iscan.esync|isync.autod|core.barge|barge.acs|barge.ddc|barge.dcl|barge.ecs|barge.gke|barge.triton|steps.rSyncSteps|steps.manifestSteps|steps.deploySteps|steps.releaseSteps|core.charon|versions.trigger|core.nf|nf.email|nf.hipchat|nf.irc|nf.slack|nf.webhook|core.certgen|core.hubspotSync|core.sync"
+        VORTEX_QUEUE_LIST: "www.sockets|marshaller.ec2|micro.ini|cluster.init|barge.ebs|micro.cu|micro.su|job.request|job.trigger|core.braintree|gitRepo.sync|steps.runCISteps|steps.runShSteps"
+        ROOT_QUEUE_LIST: "core.iscan|iscan.isync|iscan.esync|isync.autod|core.barge|barge.acs|barge.ddc|barge.dcl|barge.ecs|barge.gke|barge.triton|steps.rSyncSteps|steps.manifestSteps|steps.deploySteps|steps.releaseSteps|core.charon|versions.trigger|core.nf|nf.email|nf.hipchat|nf.irc|nf.slack|nf.webhook|core.certgen|core.hubspotSync|core.marshaller|core.sync"
 
   - name: www-repo
     type: gitRepo

--- a/shippable.triggers.yml
+++ b/shippable.triggers.yml
@@ -7,4 +7,4 @@ triggers:
    - name: trigger-deploy
      type: trigger
      version:
-       counter: 27
+       counter: 28


### PR DESCRIPTION
https://github.com/Shippable/micro/issues/3035

- Moves marshaller to shippableRoot vhost
- Alphabetizes deploy-beta-core IN manifests