### PR TITLE
Move ec2 to shippableRoot vhost

### DIFF
--- a/shippable.jobs.yml
+++ b/shippable.jobs.yml
@@ -500,11 +500,15 @@ jobs:
   - name: deploy-beta-ci
     type: deploy
     steps:
-      - IN: man-ini
+      - IN: trigger-deploy
       - IN: man-ec2
+      - IN: man-ini
       - IN: beta-docOpts
       - IN: beta-prm
       - IN: beta-clust
+      - IN: rabbitMQ-params
+        applyTo:
+          - man-ec2
 
   - name: shippable-rel
     type: release

--- a/shippable.resources.yml
+++ b/shippable.resources.yml
@@ -152,8 +152,8 @@ resources:
       params:
         SHIPPABLE_FE_URL: "https://beta.shippable.com"
         API_PORT: "443"
-        VORTEX_QUEUE_LIST: "www.sockets|marshaller.ec2|micro.ini|cluster.init|barge.ebs|micro.cu|micro.su|job.request|job.trigger|core.braintree|gitRepo.sync|steps.runCISteps|steps.runShSteps"
-        ROOT_QUEUE_LIST: "core.iscan|iscan.isync|iscan.esync|isync.autod|core.barge|barge.acs|barge.ddc|barge.dcl|barge.ecs|barge.gke|barge.triton|steps.rSyncSteps|steps.manifestSteps|steps.deploySteps|steps.releaseSteps|core.charon|versions.trigger|core.nf|nf.email|nf.hipchat|nf.irc|nf.slack|nf.webhook|core.certgen|core.hubspotSync|core.marshaller|core.sync"
+        VORTEX_QUEUE_LIST: "www.sockets|micro.ini|cluster.init|barge.ebs|micro.cu|micro.su|job.request|job.trigger|core.braintree|gitRepo.sync|steps.runCISteps|steps.runShSteps"
+        ROOT_QUEUE_LIST: "core.iscan|iscan.isync|iscan.esync|isync.autod|core.barge|barge.acs|barge.ddc|barge.dcl|barge.ecs|barge.gke|barge.triton|steps.rSyncSteps|steps.manifestSteps|steps.deploySteps|steps.releaseSteps|core.charon|versions.trigger|core.nf|nf.email|nf.hipchat|nf.irc|nf.slack|nf.webhook|core.certgen|core.hubspotSync|core.marshaller|marshaller.ec2|core.sync"
 
   - name: www-repo
     type: gitRepo

--- a/shippable.triggers.yml
+++ b/shippable.triggers.yml
@@ -7,4 +7,4 @@ triggers:
    - name: trigger-deploy
      type: trigger
      version:
-       counter: 28
+       counter: 29


### PR DESCRIPTION
https://github.com/Shippable/micro/issues/3036

- Moves ec2 to shippableRoot vhost
- Alphabetizes deploy-beta-ci IN manifests