### PR TITLE
Removes RabbitMQ vhost environment variable.

### DIFF
--- a/shippable.jobs.yml
+++ b/shippable.jobs.yml
@@ -286,14 +286,6 @@ jobs:
       - IN: beta-docOpts
       - IN: beta-prm
       - IN: beta-clust
-      - IN: rabbitMQ-params
-        applyTo:
-          - man-nf
-          - man-email
-          - man-hipchat
-          - man-irc
-          - man-slack
-          - man-webhook
 
   - name: man-barge
     type: manifest
@@ -357,7 +349,6 @@ jobs:
       - IN: beta-docOpts
       - IN: beta-prm
       - IN: beta-clust
-      - IN: rabbitMQ-params
 
   - name: man-charon
     type: manifest
@@ -415,14 +406,6 @@ jobs:
       - IN: beta-docOpts
       - IN: beta-prm
       - IN: beta-clust
-      - IN: rabbitMQ-params
-        applyTo:
-          - man-charon
-          - man-deploySteps
-          - man-manifestSteps
-          - man-releaseSteps
-          - man-rSyncSteps
-          - man-versionTrigger
 
   - name: man-sync
     type: manifest
@@ -488,15 +471,6 @@ jobs:
       - IN: beta-docOpts
       - IN: beta-prm
       - IN: beta-clust
-      - IN: rabbitMQ-params
-        applyTo:
-          - man-braintree
-          - man-certgen
-          - man-hubspotSync
-          - man-jobRequest
-          - man-jobTrigger
-          - man-marshaller
-          - man-sync
 
   - name: man-ini
     type: manifest
@@ -518,10 +492,6 @@ jobs:
       - IN: beta-docOpts
       - IN: beta-prm
       - IN: beta-clust
-      - IN: rabbitMQ-params
-        applyTo:
-          - man-ec2
-          - man-ini
 
   - name: man-isync
     type: manifest
@@ -550,11 +520,6 @@ jobs:
       - IN: beta-docOpts
       - IN: beta-prm
       - IN: beta-clust
-      - IN: rabbitMQ-params
-        applyTo:
-          - man-isync
-          - man-esync
-          - man-iscan
 
   - name: shippable-rel
     type: release

--- a/shippable.resources.yml
+++ b/shippable.resources.yml
@@ -495,12 +495,6 @@ resources:
         FOO: bar
         secure: L4uwHq35OhmAT4KjUShoW3nk7S5pXIU3UwnPyOjiOEApKbJgC9YnaBpi8ARkUcLwLJcgTffM6Qv97UJ7DIdfNMtji/6VoqEuRK9ShwQeQ+FGagbP7dpbD/NoPvO5G8IP2mPoedOlulzC2byt69QTH9ljephgRkYviesRnn4YgM9mEff5RvV9SiW/31ilfHEQXCu8T5uTD3SUcwK5s9pPwwqPaGmNDrBteyksytVi1CTB0u+K+NOd/VlOKt7U/DMaBryrr/ndzXySZ7JHPc2U+ALQA/cxrkd5zApWBGv4m4qh4345r22Z5Hv3SAQufvZfC5jo/Djspla+KTgUwmwjAw==
 
-  - name: rabbitMQ-params
-    type: params
-    version:
-      params:
-        SHIPPABLE_VHOST: shippableRoot
-
   - name: beta-docOpts
     type: dockerOptions
     version:


### PR DESCRIPTION
We don't need it anymore.