### PR TITLE
Removes VORTEX_QUEUE_LIST and unused queues from api-params

### DIFF
--- a/shippable.resources.yml
+++ b/shippable.resources.yml
@@ -166,7 +166,6 @@ resources:
       params:
         SHIPPABLE_FE_URL: "https://beta.shippable.com"
         API_PORT: "443"
-        VORTEX_QUEUE_LIST: "barge.ebs|micro.cu|micro.su|steps.runCISteps"
         ROOT_QUEUE_LIST: "www.sockets|core.iscan|iscan.isync|iscan.esync|isync.autod|core.barge|barge.acs|barge.ddc|barge.dcl|barge.ecs|barge.gke|barge.triton|steps.rSyncSteps|steps.manifestSteps|steps.deploySteps|steps.releaseSteps|core.charon|versions.trigger|core.nf|nf.email|nf.hipchat|nf.irc|nf.slack|nf.webhook|core.braintree|core.certgen|core.hubspotSync|core.marshaller|marshaller.ec2|core.sync|job.request|job.trigger|micro.ini|cluster.init"
 
   - name: www-repo


### PR DESCRIPTION
https://github.com/Shippable/www/issues/6906

- Removes VORTEX_QUEUE_LIST and unused queues from api-pararms

The list of queues in beta now reflects the queues in use. VORTEX_QUEUE_LIST is no longer used as well.