### PR TITLE
Rename stepExec JOB_TYPES and manifests to remove 'Steps' from names

### DIFF
--- a/shippable.jobs.yml
+++ b/shippable.jobs.yml
@@ -356,29 +356,29 @@ jobs:
       - IN: charon-img
       - IN: charon-params
 
-  - name: man-deploySteps
+  - name: man-deploy
     type: manifest
     steps:
       - IN: stepExec-img
-      - IN: deploySteps-params
+      - IN: deploy-params
 
-  - name: man-manifestSteps
+  - name: man-manifest
     type: manifest
     steps:
       - IN: stepExec-img
-      - IN: manifestSteps-params
+      - IN: manifest-params
 
-  - name: man-releaseSteps
+  - name: man-release
     type: manifest
     steps:
       - IN: stepExec-img
-      - IN: releaseSteps-params
+      - IN: release-params
 
-  - name: man-rSyncSteps
+  - name: man-rSync
     type: manifest
     steps:
       - IN: stepExec-img
-      - IN: rSyncSteps-params
+      - IN: rSync-params
       - IN: beta-bitbuc-params
 
   - name: man-timeTrigger
@@ -397,10 +397,10 @@ jobs:
     type: deploy
     steps:
       - IN: man-charon
-      - IN: man-deploySteps
-      - IN: man-manifestSteps
-      - IN: man-releaseSteps
-      - IN: man-rSyncSteps
+      - IN: man-deploy
+      - IN: man-manifest
+      - IN: man-release
+      - IN: man-rSync
       - IN: man-timeTrigger
       - IN: man-versionTrigger
       - IN: beta-docOpts

--- a/shippable.resources.yml
+++ b/shippable.resources.yml
@@ -164,7 +164,7 @@ resources:
       params:
         SHIPPABLE_FE_URL: "https://beta.shippable.com"
         API_PORT: "443"
-        ROOT_QUEUE_LIST: "www.sockets|core.iscan|iscan.isync|iscan.esync|isync.autod|core.barge|barge.acs|barge.ddc|barge.dcl|barge.ecs|barge.gke|barge.triton|steps.deploySteps|steps.manifestSteps|steps.releaseSteps|steps.rSyncSteps|core.charon|versions.trigger|core.nf|nf.email|nf.hipchat|nf.irc|nf.slack|nf.webhook|core.braintree|core.certgen|core.hubspotSync|core.marshaller|marshaller.ec2|core.sync|job.request|job.trigger|micro.ini|cluster.init|steps.deploy|steps.manifest|steps.rSync|steps.release"
+        ROOT_QUEUE_LIST: "www.sockets|core.iscan|iscan.isync|iscan.esync|isync.autod|core.barge|barge.acs|barge.ddc|barge.dcl|barge.ecs|barge.gke|barge.triton|core.charon|versions.trigger|core.nf|nf.email|nf.hipchat|nf.irc|nf.slack|nf.webhook|core.braintree|core.certgen|core.hubspotSync|core.marshaller|marshaller.ec2|core.sync|job.request|job.trigger|micro.ini|cluster.init|steps.deploy|steps.manifest|steps.rSync|steps.release"
 
   - name: www-repo
     type: gitRepo
@@ -584,33 +584,33 @@ resources:
       params:
         COMPONENT: "charon"
 
-  - name: deploySteps-params
+  - name: deploy-params
     type: params
     version:
       params:
         COMPONENT: "stepExec"
-        JOB_TYPE: "deploySteps"
+        JOB_TYPE: "deploy"
 
-  - name: manifestSteps-params
+  - name: manifest-params
     type: params
     version:
       params:
         COMPONENT: "stepExec"
-        JOB_TYPE: "manifestSteps"
+        JOB_TYPE: "manifest"
 
-  - name: releaseSteps-params
+  - name: release-params
     type: params
     version:
       params:
         COMPONENT: "stepExec"
-        JOB_TYPE: "releaseSteps"
+        JOB_TYPE: "release"
 
-  - name: rSyncSteps-params
+  - name: rSync-params
     type: params
     version:
       params:
         COMPONENT: "stepExec"
-        JOB_TYPE: "rSyncSteps"
+        JOB_TYPE: "rSync"
 
   - name: timeTrigger-params
     type: params


### PR DESCRIPTION
https://github.com/Shippable/beta/issues/109

For each stepExec service:
- Updates the JOB_TYPE to remove "Steps"
- Renames the params and manifests to remove "Steps"
- Removes the old queue name (e.g. steps.deploySteps)