### PR TITLE
Update baseami to use latest Ubuntu 14.04

### DIFF
--- a/shippable.resources.yml
+++ b/shippable.resources.yml
@@ -297,7 +297,7 @@ resources:
     type: params
     version:
       params:
-        SOURCE_AMI: "ami-c8580bdf"
+        SOURCE_AMI: "ami-5ac2cd4d"
         VPC_ID: "vpc-266f3241"
         SUBNET_ID: "subnet-6df12f24"
         SECURITY_GROUP_ID: "sg-f634518c"


### PR DESCRIPTION
Fixes #310 

Updates baseami-params to use the latest Ubuntu 14.04 AMI on us-east-1