### PR TITLE
fix double trigger of rel-alpha

### DIFF
--- a/shippable.jobs.yml
+++ b/shippable.jobs.yml
@@ -87,6 +87,7 @@ jobs:
       - IN: www_img
       - IN: nexec_img
       - IN: micro_img
+        switch: off
       - IN: genexec_img
       - TASK: managed
         bump: alpha


### PR DESCRIPTION
#450

this will fix the issue of rel-alpha triggering twice for each change to micro-repo.

since OUTs are processed in order, we can simply add `switch: off` to the one that is processed first (micro-img), and let the second one trigger the job.  This will ensure that both images are up to date when rel-alpha runs.