### PR TITLE
fix ship_ver so next release is 5.2.4, and fix double rc deploy

### DIFF
--- a/shippable.jobs.yml
+++ b/shippable.jobs.yml
@@ -117,6 +117,7 @@ jobs:
       - IN: nexec_img
       - IN: genexec_img
       - IN: micro_img
+        switch: off
       - TASK:
         - script: ./IN/config_repo/gitRepo/deployRc.sh
     on_success:

--- a/shippable.resources.yml
+++ b/shippable.resources.yml
@@ -127,7 +127,7 @@ resources:
   - name: ship_ver
     type: version
     seed:
-      versionName: "5.2.4"
+      versionName: "5.2.3"
 
   ###############################
   # end Shippable Server resources


### PR DESCRIPTION
#492 

only one of the two OUT images will trigger RC. they both get pushed with each change, so this should guarantee latest code is always deployed to rc.

also, setting ship_ver back one so that when rel_prod is run, the correct version is produced.