### PR TITLE
add jobs and resources for postgres core service

### DIFF
--- a/shippable.jobs.yml
+++ b/shippable.jobs.yml
@@ -532,6 +532,21 @@ jobs:
   # START Drydock image builds
   ###########################################
 
+  - name: build_postgres
+    type: runCLI
+    steps:
+      - IN: config_repo
+        switch: off
+      - IN: postgres_repo
+      - IN: ship_dh_cli
+      - TASK:
+        - script: ./IN/config_repo/gitRepo/buildImage.sh postgres drydock
+      - OUT: postgres_img
+    on_success:
+      - script: echo 'on success !!!!!'
+    on_failure:
+      - script: echo 'Failed job .... :('
+
   - name: build_u14
     type: runCLI
     steps:
@@ -1116,7 +1131,29 @@ jobs:
     on_failure:
       - script: echo 'Failed job .... :('
 
-  ### Taggin u14 images
+  ### Tagging core services
+  - name: tag_push_postgres
+    type: runCLI
+    steps:
+      - IN: config_repo
+        switch: off
+      - IN: avi_gh_ssh
+        switch: off
+      - IN: postgres_img
+        switch: off
+      - IN: postgres_repo
+        switch: off
+      - IN: ship_dh_cli
+        switch: off
+      - IN: rel_prod
+      - TASK:
+        - script: ./IN/config_repo/gitRepo/tagAndPushImageRepo.sh postgres drydock dry-dock
+    on_success:
+      - script: echo 'on success !!!!!'
+    on_failure:
+      - script: echo 'Failed job .... :('
+
+  ### Tagging u14 images
   - name: tag_push_u14
     type: runCLI
     steps:
@@ -1348,7 +1385,7 @@ jobs:
     on_failure:
       - script: echo 'Failed job .... :('
 
-  ### Taggin u16 images
+  ### Tagging u16 images
   - name: tag_push_u16
     type: runCLI
     steps:

--- a/shippable.resources.yml
+++ b/shippable.resources.yml
@@ -344,6 +344,22 @@ resources:
   ###############################
   # BEGIN drydock resources
   ###############################
+
+  - name: postgres_repo
+    type: gitRepo
+    integration: ric03uec-github
+    pointer:
+      sourceName: dry-dock/postgres
+      branch: master
+
+  - name: postgres_img
+    type: image
+    integration: shipDH
+    pointer:
+      sourceName: "drydock/postgres"
+    seed:
+      versionName: latest
+
   - name: u14_repo
     type: gitRepo
     integration: ric03uec-github


### PR DESCRIPTION
#564

adds a job to push postgres image to drydock master on every change.

when rel-prod is run, pulls master, re-tags as the release version, and pushes the new tag.