### PR TITLE
Switch off bvt, use bvt-2

### DIFF
--- a/shippable.jobs.yml
+++ b/shippable.jobs.yml
@@ -272,6 +272,7 @@ jobs:
       - IN: bat_repo
       - IN: bvt_params
       - IN: deploy_rc
+        switch: off
       - TASK:
         - script: IN/bat_repo/gitRepo/test.sh bvt_params
     on_success:
@@ -1895,7 +1896,7 @@ jobs:
   - name: unlock_team
     type: runCLI
     steps:
-      - IN: bvt
+      - IN: bvt-v2
       - IN: team_params
       - IN: config_repo
         switch: off


### PR DESCRIPTION
https://github.com/Shippable/beta/issues/621

Since BVT runs into issues frequently, it causes significant time-sink. We'll switch to BVT-2 so we don't run into this. We will still run BVT everyday and before any releases to ensure things are okay. Eventually when BVT-2 catches up with test cases, this will be removed.