### PR TITLE
force pulls latest version of image

### DIFF
--- a/buildImage.sh
+++ b/buildImage.sh
@@ -39,7 +39,7 @@ create_image() {
   sed -i "s/{{%TAG%}}/$TAG_NAME/g" Dockerfile
 
   echo "Starting Docker build & push for $BLD_IMG"
-  sudo docker build -t=$BLD_IMG .
+  sudo docker build -t=$BLD_IMG --pull .
   echo "Pushing $BLD_IMG"
   sudo docker push $BLD_IMG
   echo "Completed Docker build &  push for $BLD_IMG"


### PR DESCRIPTION
The new SMIs have the drydock master images. This causes a problem while building images.
For eg., if we make any changes to drydock/u14 which triggers drydock/microbase, drydock/microbase will not pull the latest drydock/u14 image since it is already present in the machine.

This PR pulls the latest version of the base image, if present, while building the image.