### PR TITLE
add patch job for v5.8.2

### DIFF
--- a/shippable.jobs.yml
+++ b/shippable.jobs.yml
@@ -650,6 +650,26 @@ jobs:
     on_failure:
       - script: cat /build/IN/bldami_repo/gitRepo/exec/output.txt
 
+  - name: build_v582
+    type: runSh
+    steps:
+      - IN: baseami_params
+      - IN: aws_bits_access
+      - IN: tag_push_img_genexec
+        switch: off
+      - IN: tag_push_cexec
+        switch: off
+      - IN: tag_push_node
+        switch: off
+      - IN: bldami_repo
+        switch: off
+      - IN: rel_prod
+        switch: off
+      - TASK:
+        - script: IN/bldami_repo/gitRepo/exec/execPackTmp.sh build_v582 rel_prod ami-f9d6e782 v582 Ubuntu_14.04_Docker_17.06.sh true
+    on_failure:
+      - script: cat /build/IN/bldami_repo/gitRepo/exec/output.txt
+
   - name: build_stable
     type: runSh
     steps:


### PR DESCRIPTION
- Picked `buildfinal_ami` id from [lastest job](https://app.shippable.com/github/Shippable/jobs/build_finalami/builds/5991ae36ecc47f0700b827e1/console)
- Verified version from `getSystemMachineImage`
- Also updates scripts to Docker 1.17