### PR TITLE
Use the correct integration for pushing artifact

### DIFF
--- a/shippable.jobs.yml
+++ b/shippable.jobs.yml
@@ -226,7 +226,7 @@ jobs:
         switch: off
       - IN: micro_repo
       - IN: reqExec_repo
-      - IN: shipbits_ecr_v2_cli
+      - IN: aws_v2_bits_access_cli
       - TASK:
         - script: ./IN/config_repo/gitRepo/buildAndPushReqExecArtifacts.sh x86_64 Ubuntu s3://shippable-artifacts us-east-1
 

--- a/shippable.resources.yml
+++ b/shippable.resources.yml
@@ -335,6 +335,12 @@ resources:
     type: integration
     integration: aws_bits_access
 
+  - name: aws_v2_bits_access_cli
+    type: cliConfig
+    integration: aws_bits_access
+    pointer:
+      region: us-east-1
+
   - name: baseami_params
     type: params
     version:


### PR DESCRIPTION
Incorrectly assumed that the ecr integration has access to the buckets as well. The aws integration seems to have full access.

https://github.com/Shippable/beta/issues/763