### PR TITLE
fix indentation and double micro triggering

### DIFF
--- a/shippable.jobs.yml
+++ b/shippable.jobs.yml
@@ -266,6 +266,7 @@ jobs:
       - IN: genexec_img
       - IN: mktg_img
       - IN: micro_img
+        switch: off
       - IN: admiral_img
       - TASK:
         - script: ./IN/config_repo/gitRepo/deployRc.sh

--- a/shippable.resources.yml
+++ b/shippable.resources.yml
@@ -27,7 +27,7 @@ resources:
     pointer:
       sourceName: shippable/nexec
       branch: master
-    buildOnCommit: false
+      buildOnCommit: false
 
   - name: nexec_img
     type: image
@@ -50,7 +50,7 @@ resources:
     pointer:
       sourceName: shippable/cexec
       branch: master
-    buildOnCommit: false
+      buildOnCommit: false
 
   - name: execTemplates_repo
     type: gitRepo
@@ -138,7 +138,7 @@ resources:
     pointer:
       sourceName: shippable/api
       branch: master
-    buildOnCommit: false
+      buildOnCommit: false
 
   - name: api_img
     type: image
@@ -161,7 +161,7 @@ resources:
     pointer:
       sourceName: shippable/www
       branch: master
-    buildOnCommit: false
+      buildOnCommit: false
 
   - name: www_img
     type: image
@@ -184,7 +184,7 @@ resources:
     pointer:
       sourceName: shippable/micro
       branch: master
-    buildOnCommit: false
+      buildOnCommit: false
 
   - name: micro_img
     type: image
@@ -215,7 +215,7 @@ resources:
     pointer:
       sourceName: shippable/mktg
       branch: master
-    buildOnCommit: false
+      buildOnCommit: false
 
   - name: mktg_img
     type: image


### PR DESCRIPTION
Shippable/heap#1710

fixes indentation for the buildOnCommit flag.
also fixes the double triggering when micro repo has commits.